### PR TITLE
Change account page to use github_id instead of username

### DIFF
--- a/lintable_web/__init__.py
+++ b/lintable_web/__init__.py
@@ -195,10 +195,14 @@ if not DEBUG:
 
         github_user = Github(access_token).get_user()
         github_user_id = github_user.id
+        github_name = github_user.name
+        if not github_name:
+            github_name = github_user.login
 
         user = DatabaseHandler.get_user(github_user_id)
         if user is None:
-            user = User(github_id=github_user_id, token=access_token)
+            user = User(github_id=github_user_id, token=access_token,
+                        username=github_name)
             user.save()
 
         login_user(user)

--- a/lintable_web/templates/account.html
+++ b/lintable_web/templates/account.html
@@ -17,7 +17,7 @@ limitations under the License.
 {% extends "_wrapper.html" %}
 
 {% block headtitle %}Lintable | Account{% endblock %}
-{% block pagetitle %}Account: {{ current_user.github_id }}{% endblock %}
+{% block pagetitle %}Account: {{ current_user.username if current_user.username is not None else currentuser.github_id }}{% endblock %}
 
 {% block content %}
   {% for repo in current_user.repos %}


### PR DESCRIPTION
**_1 Upvote**_ Straightforward enough. We sometimes or always lack username by default, but we always have the github_id.
