### PR TITLE
Remove escape filter only used in one place

### DIFF
--- a/lintable_web/templates/status.html
+++ b/lintable_web/templates/status.html
@@ -21,7 +21,7 @@ limitations under the License.
 {% block pagetitle %}
   Status
   {% if job %}
-    for job {{ job.job_id|e }}
+    for job {{ job.job_id }}
     <small><a class="btn btn-info btn-sm" href="/status"><span class="octicon octicon-triangle-up"></span></a></small>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
**_1 Upvote**_ This might be what's causing that 500 error, and it's the only place it's used anyway. It'd be better to remove it and then add more comprehensive safety checking in a separate pass.
