### PR TITLE
removed comment_id from the process handler related classes

### DIFF
--- a/lintable_processes/db_handler.py
+++ b/lintable_processes/db_handler.py
@@ -57,10 +57,10 @@ class DBHandler(DoNothingHandler):
             summary.error_count = len(lint_report.errors[summary.file_name])
             summary.save()
 
-    def started(self, uuid: UUID, comment_id: int = None):
+    def started(self, uuid: UUID):
         """Kicks off the process."""
 
-        super().started(uuid, comment_id)
+        super().started(uuid)
         self.repo_fk = DatabaseHandler.get_repo(identifier=self.repo_id)
         self.job = Jobs.create(job_id=uuid,
                                repo_owner=self.repo_fk.owner_id,

--- a/lintable_processes/do_nothing_handler.py
+++ b/lintable_processes/do_nothing_handler.py
@@ -26,7 +26,7 @@ class DoNothingHandler(object):
     def __init__(self):
         pass
 
-    def started(self, uuid: UUID, comment_id: int = None):
+    def started(self, uuid: UUID):
         """Kicks off the process."""
 
         return

--- a/lintable_processes/log_handler.py
+++ b/lintable_processes/log_handler.py
@@ -59,13 +59,11 @@ class LogHandler(DoNothingHandler):
             else:
                 self.logger.info('{file} contained no errors.'.format(file=file))
 
-    def started(self, uuid: UUID, comment_id: int = None):
+    def started(self, uuid: UUID):
         """Kicks off the process."""
 
-        super().started(uuid, comment_id)
+        super().started(uuid)
         self.logger.info('Starting linting process with id: {uuid}'.format(uuid=uuid))
-        if type(comment_id) is int and comment_id >= 0:
-            self.logger.debug('Comment id is {comment_id}'.format(comment_id=comment_id))
 
     def clone_repo(self, uuid: UUID, repo: Repo, local_path: str):
         """Indicates a repo has been cloned and where that clone is located."""

--- a/lintable_processes/process_handler.py
+++ b/lintable_processes/process_handler.py
@@ -44,7 +44,6 @@ class ProcessHandler(object):
         self.a_path = None
         self.b_path = None
         self.files = []
-        self.comment_id = None
 
     def started(self):
         """Kicks off the process.
@@ -52,9 +51,8 @@ class ProcessHandler(object):
         :return:
         """
 
-        self.comment_id = self.status_updater.started(uuid=self.uuid)
-        self.logger.started(uuid=self.uuid, comment_id=self.comment_id)
-        self.db.started(uuid=self.uuid, comment_id=self.comment_id)
+        self.logger.started(uuid=self.uuid)
+        self.db.started(uuid=self.uuid)
 
     def clone_repo(self, local_path: str, repo_path: str, a_path: str, b_path: str):
         """Indicates a repo has been cloned and where that clone is located.

--- a/lintable_processes/status_handler.py
+++ b/lintable_processes/status_handler.py
@@ -36,7 +36,7 @@ class StatusHandler(DoNothingHandler):
 
     def lint_file(self, uuid: UUID, linter: str, file: str):
         super().lint_file(uuid, linter, file)
-        if self.linting_files == False:
+        if not self.linting_files:
             self.linting_files = True
             self.github_commit.create_status(state='pending',
                                              target_url=self.target_url,
@@ -59,9 +59,9 @@ class StatusHandler(DoNothingHandler):
                                              description='Total number of files processed: {nof}\t Files with errors: {fwe}'.format(nof=num_of_files,fwe=len(files_with_errors)),
                                              context=LINTABLE)
 
-    def started(self, uuid: UUID, comment_id: int = None):
+    def started(self, uuid: UUID):
         self.logger.error('target_url= {url}'.format(url=self.target_url))
-        super().started(uuid, comment_id)
+        super().started(uuid)
         self.github_commit.create_status(state='pending',
                                          target_url=self.target_url,
                                          description='Starting linting process',

--- a/lintable_processes/test_db_handler.py
+++ b/lintable_processes/test_db_handler.py
@@ -65,10 +65,9 @@ class DBHandlerTests(unittest.TestCase):
 
         self.db_handler = DBHandler(repo_id=self.repo1.repo_id)
         self.uuid = uuid4()
-        self.comment_number = 42
         self.tmp_dir = tempfile.mkdtemp()
         self.git_repo = git.Repo.init(path=self.tmp_dir, mkdir=False)
-        self.db_handler.started(self.uuid, self.comment_number)
+        self.db_handler.started(self.uuid)
 
     def tearDown(self):
 
@@ -88,7 +87,7 @@ class DBHandlerTests(unittest.TestCase):
 
     def test_started(self):
         with test_database(test_db, ()):
-            self.db_handler.started(self.uuid, self.comment_number)
+            self.db_handler.started(self.uuid)
             self.get_and_check_job_status(status='STARTED')
 
     def test_clone_repo(self):


### PR DESCRIPTION
**_1 Upvote**_ We use GitHub's status system so we don't need a comment id to post comments with.
