### PR TITLE
add route and model for letsencrypt (ACME)

### DIFF
--- a/lintable_db/database.py
+++ b/lintable_db/database.py
@@ -18,7 +18,7 @@ import logging
 from typing import Union
 from uuid import UUID
 
-from lintable_db.models import User, Repo, Jobs
+from lintable_db.models import User, Repo, Jobs, AcmeChallengeResponse
 
 logger = logging.getLogger(__name__)
 
@@ -120,3 +120,19 @@ class DatabaseHandler:
             logger.error(e)
 
         return job
+
+    @staticmethod
+    def get_acme_response(identifier: str) -> str:
+        """Look up an ACME response by challenge identifier.
+
+        The value must already be in the database.
+
+        :param identifier: CA-provided challenge ID.
+        :return str: CA-provided challenge response."""
+        try:
+          return AcmeChallengeResponse.get(
+              AcmeChallengeResponse.challenge_identifier == identifier
+            ).challenge_response
+        except Exception as e:
+            logger.error(e)
+            return "Challenge identifier not found."

--- a/lintable_db/models.py
+++ b/lintable_db/models.py
@@ -159,3 +159,9 @@ class GithubString(BaseModel):
     """A test state placeholder."""
 
     state_string = CharField()
+
+class AcmeChallengeResponse(BaseModel):
+    """A challenge and associated response, for use with an ACME CA."""
+
+    challenge_identifier = CharField()
+    challenge_response = CharField()

--- a/lintable_web/__init__.py
+++ b/lintable_web/__init__.py
@@ -231,6 +231,11 @@ if not DEBUG:
         LOGGER.error('url_for(\'account\'): {}'.format( url_for('account')))
         return redirect(request.args.get('next') or url_for('account'))
 
+    @app.route('/.well-known/acme-challenge/<identifier>')
+    def letsencrypt(identifier=None):
+        """Respond to a letsencrypt ACME challenge."""
+        return DatabaseHandler.get_acme_response(identifier)
+
 ################################################################################
 # Start the server
 ################################################################################


### PR DESCRIPTION
**_2 Upvotes**_ # Background

[Let's Encrypt](https://letsencrypt.org/) is an SSL provider. To issue certificates, it requires a customer's website to respond to a request issued to an endpoint negotiated out of band, and expect a response agreed upon at the same time as the endpoint.

They provide a script to automatically do this negotiation and response, and the expected workflow is to run this script with root credentials so that it can also automatically request and renew your SSL certificate, as well as automatically reconfigure your httpd to use it.

That doesn't work out so well in a Heroku context. However, there are more manual options. According to [1], letsencrypt expects its challenge to be present at `/.well-known/acme-challenge/:id`, and in the manual workflow gives you time to configure your webserver to respond appropriately.

Once that challenge/response interaction is complete, the CA will sign the certificate request, and the certificate can be uploaded to Heroku.
# Functionality

Respond to requests at `/.well-known/acme-challenge/:id` with the value in the `acmechallengeresponse` table matching the `:id`.
# Deployment

``` python
import models
db = models.User._meta.database
db.connect()
db.create_table(models.AcmeChallengeResponse)
```

And then, during the Let's Encrypt dance,

```
$ heroku pg:psql --app lintable
lintable::DATABASE=> INSERT INTO acmechallengeresponse
  (challenge_identifier, challenge_response)
  values ('asdf', 'jkl');
```
# Testing done

Deployed to lintable-test

---

[1] http://collectiveidea.com/blog/archives/2016/01/12/lets-encrypt-with-a-rails-app-on-heroku/

Issue #144 Set up HTTPS
